### PR TITLE
Fixed Facebook Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
     
                 <ul class="header-nav__social">
                     <li>
-                        <a href="https://m.facebook.com/clabsvit/"><i class="fa fa-facebook"></i></a>
+                        <a href="https://facebook.com/clabsvit/"><i class="fa fa-facebook"></i></a>
                     </li>
                     <li>
                         <a href="https://www.linkedin.com/company/creationlabs/" target="_blank"><i class="fa fa-linkedin"></i></a>


### PR DESCRIPTION
The m.facebook.com domain always opens a mobile version of facebook even when opened on a Desktop, while the facebook.com domain would redirect to m.facebook automatically if opened on a mobile device. 
so changed the link to facebook.com